### PR TITLE
feat(linux): github action for automated linux release

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build_linux:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+    steps:
+      - name: set git global safe directory
+        run: |
+          pacman -Syu git npm --noconfirm
+          git config --global --add safe.directory $(realpath .)
+
+      - uses: actions/checkout@v4
+
+      - name: build AppImage
+        run: |
+          npm install
+          npm run build --linux
+          chmod +x dist/YouTubeTV_v*_linux.AppImage
+        continue-on-error: true
+
+      - name: show files
+        run: |
+          ls ./dist/YouTubeTV_v*_linux.AppImage
+
+      - name: Publish Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: youtube-tv-client
+          path: ./dist/YouTubeTV_v*_linux.AppImage
+
+  publish:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs: build_linux
+    steps:
+      - run: mkdir /tmp/artifacts
+
+      - name: download artifact
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/artifacts
+
+      - run: ls -R /tmp/artifacts
+
+      - name: publish to github release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: /tmp/artifacts/youtube-tv-client/YouTubeTV_v*_linux.AppImage
+          tag_name: ${{ github.ref_name }}
+          body: |
+            Youtube TV Client Release
+          draft: true
+          generate_release_notes: true
+          prerelease: contains(github.ref, 'pre')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "youtube-tv-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "youtube-tv-client",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "devDependencies": {
-        "electron": "^31.3.0",
+        "electron": "github:castlabs/electron-releases#v31.3.1+wvcus",
         "electron-builder": "^24.13.3"
       }
     },
@@ -1635,11 +1635,11 @@
       }
     },
     "node_modules/electron": {
-      "version": "31.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-31.3.0.tgz",
-      "integrity": "sha512-3LMRMmK4UK0A+jYSLGLYdfhc20TgY2v5jD3iGmhRZlDYj0gn7xBj/waRjlNalysZ0D2rgPvoes0wHuf5e/Bguw==",
+      "version": "31.3.1+wvcus",
+      "resolved": "git+ssh://git@github.com/castlabs/electron-releases.git#ebcba2378b8d1117e834b0513eb693c8c7d1016a",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^20.9.0",

--- a/package.json
+++ b/package.json
@@ -11,17 +11,24 @@
   "build": {
     "appId": "com.haroon01.youtubetvclient",
     "productName": "YouTubeTV",
+    "electronDownload": {
+      "mirror": "https://github.com/castlabs/electron-releases/releases/download/v"
+    },
     "files": [
       "index.js",
       "package.json"
     ],
     "win": {
-      "target": ["portable"],
+      "target": [
+        "portable"
+      ],
       "icon": "img/icon/youtube.ico",
       "artifactName": "${productName}_v${version}_x64_win.${ext}"
     },
     "linux": {
-      "target": ["AppImage"],
+      "target": [
+        "AppImage"
+      ],
       "icon": "img/icon/youtube.png",
       "artifactName": "${productName}_v${version}_linux.${ext}",
       "category": "Utility"
@@ -31,7 +38,7 @@
   "author": "Haroon01",
   "license": "ISC",
   "devDependencies": {
-    "electron": "^31.3.0",
+    "electron": "github:castlabs/electron-releases#v31.3.1+wvcus",
     "electron-builder": "^24.13.3"
   }
 }


### PR DESCRIPTION
This PR adds an automated build for the Linux AppImage.

By tagging a git commit in the format of `v0.0.0` (replace nums with actual version number), github will automatically build the Linux AppImage + create a release draft on Github.

The Github release draft will still need to be manually published.

You can see an example of the auto-generated release on my fork: https://github.com/aarron-lee/youtube-tv-client/releases

I do not know how to automate a windows build, the windows build automation would need to be added separately.