### PR TITLE
feat(linux): github action for automated release

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build_linux:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+    steps:
+      - name: set git global safe directory
+        run: |
+          pacman -Syu git npm --noconfirm
+          git config --global --add safe.directory $(realpath .)
+
+      - uses: actions/checkout@v4
+
+      - name: build AppImage
+        run: |
+          npm install
+          npm run build --linux
+          chmod +x dist/YouTubeTV_v*_linux.AppImage
+        continue-on-error: true
+
+      - name: show files
+        run: |
+          ls ./dist/YouTubeTV_v*_linux.AppImage
+
+      - name: Publish Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: youtube-tv-client
+          path: ./dist/YouTubeTV_v*_linux.AppImage
+
+  publish:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs: build_linux
+    steps:
+      - run: mkdir /tmp/artifacts
+
+      - name: download artifact
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/artifacts
+
+      - run: ls -R /tmp/artifacts
+
+      - name: publish to github release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: /tmp/artifacts/youtube-tv-client/YouTubeTV_v*_linux.AppImage
+          tag_name: ${{ github.ref_name }}
+          body: |
+            Youtube TV Client Release
+          draft: true
+          generate_release_notes: true
+          prerelease: contains(github.ref, 'pre')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
fixes https://github.com/Haroon01/youtube-tv-client/issues/6

followup to previous PR #5 

This PR adds an automated build for the Linux AppImage.

By tagging a git commit in the format of v0.0.0 (replace nums with actual version number), github will automatically build the Linux AppImage + create a release draft on Github.

The Github release draft will still need to be manually published.

You can see an example of the auto-generated release on my fork: https://github.com/aarron-lee/youtube-tv-client/releases

I do not know how to automate a windows build, the windows build automation would need to be added separately.
